### PR TITLE
Add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+_default:
+  @just --list --unsorted
+
+# Download source from internet
+download source:
+    cd pipelines && uv run python source_download.py {{source}}
+
+# Download debug sources
+[group('debug')]
+download-debug-sources: (download "debug-glo30") (download "debug-swissalti3d")
+
+# Create bounds for source
+bounds source:
+    cd pipelines && uv run python source_bounds.py {{source}}
+
+# Create bounds for debug sources
+[group('debug')]
+bounds-debug-sources: (bounds "debug-glo30") (bounds "debug-swissalti3d")
+
+# Aggregation covering
+aggregation-covering:
+    cd pipelines && uv run python aggregation_covering.py
+
+# Downsampling covering
+downsampling-covering:
+    cd pipelines && uv run python downsampling_covering.py
+
+# Run debug pipeline
+pipeline: download-debug-sources bounds-debug-sources aggregation-covering downsampling-covering

--- a/justfile
+++ b/justfile
@@ -6,7 +6,6 @@ download source:
     cd pipelines && uv run python source_download.py {{source}}
 
 # Download debug sources
-[group('debug')]
 download-debug-sources: (download "debug-glo30") (download "debug-swissalti3d")
 
 # Create bounds for source
@@ -14,7 +13,6 @@ bounds source:
     cd pipelines && uv run python source_bounds.py {{source}}
 
 # Create bounds for debug sources
-[group('debug')]
 bounds-debug-sources: (bounds "debug-glo30") (bounds "debug-swissalti3d")
 
 # Aggregation covering


### PR DESCRIPTION
Exciting to see the first source code!

This PR adds my favorite tool for running commands: [just](https://just.systems/man/en/).

As an example, I've added the CI commands, which gives this list of recipes:

```
$ just
Available recipes:
    download source        # Download source from internet
    bounds source          # Create bounds for source
    aggregation-covering   # Aggregation covering
    downsampling-covering  # Downsampling covering
    pipeline               # Run debug pipeline

    [debug]
    download-debug-sources # Download debug sources
    bounds-debug-sources   # Create bounds for debug sources
```

With that, you can run certain steps, like `just download glo30`, or a full pipeline with `just pipeline`. If you're interested, I'm happy to maintain this justfile.