### PR TITLE
Add attribution.py

### DIFF
--- a/pipelines/attribution.py
+++ b/pipelines/attribution.py
@@ -1,0 +1,30 @@
+from glob import glob
+import json
+
+import utils
+
+def main():
+    aggregation_id = utils.get_aggregation_ids()[-1]
+    filepaths = glob(f'aggregation-store/{aggregation_id}/*-aggregation.csv')
+
+    sources = set({})
+    for filepath in filepaths:
+        grouped_source_items = utils.get_grouped_source_items(filepath)
+        for source_items in grouped_source_items:
+            for source_item in source_items:
+                sources.add(source_item['source'])
+
+    csv = ['"name","website","license","producer","license_pdf"\n']
+    for source in sources:
+        with open(f'../source-catalog/{source}/metadata.json') as f:
+            metadata = json.load(f)
+            line = [metadata['name'], metadata['website'], metadata['license'], metadata['producer'], f'https://github.com/mapterhorn/mapterhorn/blob/main/source-catalog/{source}/LICENSE.pdf']
+            line = [entry.replace('"', '""') for entry in line]
+            line = [f'"{entry}"' for entry in line]
+            csv.append(','.join(line) + '\n')
+
+    with open('bundle-store/attribution.csv', 'w') as f:
+        f.writelines(csv)
+
+if __name__ == '__main__':
+    main()

--- a/pipelines/debug.sh
+++ b/pipelines/debug.sh
@@ -16,3 +16,4 @@ uv run python remove_dangling_pmtiles.py
 TMPDIR=/tmp uv run python bundle.py 0.0.0
 
 uv run python download_urls.py 0.0.0
+uv run python attribution.py

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -32,19 +32,6 @@ def create_folder(path):
     folder_path = Path(path)
     folder_path.mkdir(parents=True, exist_ok=True)
 
-def rsync(src, dst, skip_data_files=False):
-    command = f'rsync -avh {src} {dst}'
-    if skip_data_files:
-        command += ' --exclude "*.tiff"'
-        command += ' --exclude "*.tif"'
-        command += ' --exclude "*.pmtiles"'
-    run_command(command)
-
-def get_collection_items(source, collection_id):
-    paths = glob(f'cogify-store/3857/{source}/{collection_id}/*.json')
-    filenames = [path.split('/')[-1] for path in paths]
-    return [item for item in filenames if item not in ['collection.json', 'covering.json', 'source.json']]
-
 def get_aggregation_ids():
     '''
     returns aggregation ids ordered from oldest to newest

--- a/source-catalog/README.md
+++ b/source-catalog/README.md
@@ -39,14 +39,13 @@ Contains a copy of the original source license in PDF format. This can be a prin
 
 ### `metadata.json`
 
-Contains information about the source data producer, the source license, and the spatial resolution.
+Contains information about the source data producer and the source license.
 
 Example `swissalti3d/metadata.json`:
 
 ```
 {
     "name": "swissALTI3D",
-    "resolution-m": 0.5,
     "website": "https://www.swisstopo.admin.ch/en/height-model-swissalti3d",
     "license": "Open Government Data",
     "producer": "Federal Office of Topography swisstopo"

--- a/source-catalog/debug-glo30/metadata.json
+++ b/source-catalog/debug-glo30/metadata.json
@@ -1,6 +1,5 @@
 {
     "name": "COPERNICUS GLO-30",
-    "resolution-m": 30,
     "website": "https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM",
     "license": "COPERNICUS full, free and open license",
     "producer": "DLR e.V. 2010-2014, Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS by the European Union and ESA"

--- a/source-catalog/debug-swissalti3d/metadata.json
+++ b/source-catalog/debug-swissalti3d/metadata.json
@@ -1,6 +1,5 @@
 {
     "name": "swissALTI3D",
-    "resolution-m": 0.5,
     "website": "https://www.swisstopo.admin.ch/en/height-model-swissalti3d",
     "license": "Open Government Data",
     "producer": "Federal Office of Topography swisstopo"

--- a/source-catalog/glo30/metadata.json
+++ b/source-catalog/glo30/metadata.json
@@ -1,6 +1,5 @@
 {
     "name": "COPERNICUS GLO-30",
-    "resolution-m": 30,
     "website": "https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM",
     "license": "COPERNICUS full, free and open license",
     "producer": "DLR e.V. 2010-2014, Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS by the European Union and ESA. All rights reserved. Accessed via OpenTopography and AWS Open Data."

--- a/source-catalog/swissalti3d/metadata.json
+++ b/source-catalog/swissalti3d/metadata.json
@@ -1,6 +1,5 @@
 {
     "name": "swissALTI3D",
-    "resolution-m": 0.5,
     "website": "https://www.swisstopo.admin.ch/en/height-model-swissalti3d",
     "license": "Open Government Data",
     "producer": "Federal Office of Topography swisstopo"


### PR DESCRIPTION
The script attribution.py creates a file in `bundle-store/attribution.csv` which looks like this:

```
"name","website","license","producer","license_pdf"
"swissALTI3D","https://www.swisstopo.admin.ch/en/height-model-swissalti3d","Open Government Data","Federal Office of Topography swisstopo","https://github.com/mapterhorn/mapterhorn/blob/main/source-catalog/swissalti3d/LICENSE.pdf"
"COPERNICUS GLO-30","https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM","COPERNICUS full, free and open license","DLR e.V. 2010-2014, Airbus Defence and Space GmbH 2014-2018, provided under COPERNICUS by the European Union and ESA. All rights reserved. Accessed via OpenTopography and AWS Open Data.","https://github.com/mapterhorn/mapterhorn/blob/main/source-catalog/glo30/LICENSE.pdf"

```
