### PR TITLE
Remove CRS, increase vertical resolution, fix issue with three overlapping sources

### DIFF
--- a/pipelines/aggregation_merge.py
+++ b/pipelines/aggregation_merge.py
@@ -29,6 +29,10 @@ def merge(filepath):
         return
     
     num_tiff_files = len(glob(f'{tmp_folder}/*.tiff'))
+
+    if num_tiff_files == 0:
+        raise ValueError(f'failed to read tifs of {filepath}')
+
     if num_tiff_files == 1:
         print('single file...')
         command = f'touch {done_filepath}'
@@ -70,7 +74,8 @@ def merge(filepath):
         print(f'alpha_mask done in {time.time() - t1} s...')
 
         t1 = time.time()
-        merged = current * (1 - alpha_mask) + merged * alpha_mask
+        current_has_data = (current != -9999)
+        merged[current_has_data] = current[current_has_data] * (1 - alpha_mask[current_has_data]) + merged[current_has_data] * alpha_mask[current_has_data]
         print(f'merging done in {time.time() - t1} s...')
 
         if -9999 not in merged:

--- a/pipelines/remove_dangling_pmtiles.py
+++ b/pipelines/remove_dangling_pmtiles.py
@@ -12,7 +12,10 @@ for filepath in filepaths:
     filename = filepath.split('/')[-1]
     expected_pmtiles_filenames.append(filename.replace('-aggregation.csv', '.pmtiles').replace('-downsampling.csv', '.pmtiles'))
 
-pmtiles_filepaths = glob(f'pmtiles-store/*.pmtiles')
+pmtiles_filepaths = glob(f'pmtiles-store/*.pmtiles') + glob(f'pmtiles-store/*/*.pmtiles')
+
+print(len(expected_pmtiles_filenames))
+print(len(pmtiles_filepaths))
 for pmtiles_filepath in pmtiles_filepaths:
     pmtiles_filename = pmtiles_filepath.split('/')[-1]
     if pmtiles_filename not in expected_pmtiles_filenames:

--- a/pipelines/source_bounds.py
+++ b/pipelines/source_bounds.py
@@ -12,24 +12,23 @@ def main():
     else:
         print('source argument missing...')
         exit()
-
+    
     filepaths = sorted(glob(f'source-store/{source}/*'))
 
-    bounds_file_lines = ['filename,left,bottom,right,top,width,height,crs\n']
+    bounds_file_lines = ['filename,left,bottom,right,top,width,height\n']
 
     for j, filepath in enumerate(filepaths):
-        if filepath.endswith('.csv'):
+        if not filepath.endswith('.tif'):
             continue
         with rasterio.open(filepath) as src:
             left, bottom, right, top = transform_bounds(src.crs, 'EPSG:3857', *src.bounds)
             filename = filepath.split('/')[-1]
-            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{src.width},{src.height},{src.crs}\n')
+            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{src.width},{src.height}\n')
             if j % 100 == 0:
                 print(f'{j} / {len(filepaths)}')
 
     with open(f'source-store/{source}/bounds.csv', 'w') as f:
         f.writelines(bounds_file_lines)
-
 
 if __name__ == '__main__':
     main()

--- a/pipelines/source_download.py
+++ b/pipelines/source_download.py
@@ -1,21 +1,37 @@
 import utils
 import sys
+from glob import glob
+import zipfile
+import os
+import shutil
 
 def download_from_internet(source):
     urls = []
     with open(f'../source-catalog/{source}/file_list.txt') as f:
-        line = f.readline().strip()
-        while line != '':
-            urls.append(line)
-            line = f.readline().strip()
+        urls = [l.strip() for l in f.readlines()]
     j = 0
     for url in urls:
         j += 1
         if j % 100 == 0:
             print(f'downloaded {j} / {len(urls)}')
-        filename = url.split('/')[-1]
-        command = f'wget --no-verbose -O source-store/{source}/{filename} -c {url}'
+
+        # filepaths_before = glob(f'source-store/{source}/*')
+        command = f'cd source-store/{source} && wget --no-verbose --continue "{url}"'
         utils.run_command(command, silent=False)
+        # filepaths_after = glob(f'source-store/{source}/*')
+        # new_filepaths = list(set(filepaths_after) - set(filepaths_before))
+        # if len(new_filepaths) == 1:
+        #     filepath = new_filepaths[0]
+        #     if zipfile.is_zipfile(filepath):
+        #         utils.run_command(f'unzip -o {filepath} -d source-store/{source}/tmp/', silent=False)
+        #         utils.run_command(f'rm {filepath}', silent=False)
+        #         tif_filepaths = glob(f'source-store/{source}/tmp/**/*.tif', recursive=True)
+        #         for tif_filepath in tif_filepaths:
+        #             tif_filename = tif_filepath.split('/')[-1]
+        #             utils.run_command(f'mv {tif_filepath} source-store/{source}/{tif_filename}')
+        #         for entry in os.scandir(f'source-store/{source}/'):
+        #             if entry.is_dir():
+        #                 shutil.rmtree(entry.path)
 
 def main():
     source = None

--- a/website/index.html
+++ b/website/index.html
@@ -49,11 +49,10 @@
             <li>◻️ Austria, Salzburg, 1 m</li>
             <li>◻️ Austria, Oberösterreich, 0.5 m</li>
             <li>◻️ Austria, Wien, 1 m</li>
-            <li>◻️ Austria, Kärnten, 5 m</li>
-            <li>◻️ Austria, Salzburg, 1 m</li>
+            <li>◻️ Austria, Kärnten, 1 m</li>
             <li>◻️ Belgium, Flanders, 1 m</li>
             <li>◻️ Belgium, Wallonie, 1 m</li>
-            <li>◻️ Czech Republic, country-wide, 1 m</li>
+            <li>◻️ Czech Republic, country-wide, 5 m</li>
             <li>◻️ Denmark, country-wide, 0.5 m</li>
             <li>◻️ Estonia, country-wide, 1 m</li>
             <li>◻️ Finland, country-wide, 2 m</li>


### PR DESCRIPTION
Removes the CRS information from bounds.csv since rasterio can get this info directly from the tifs.

Increases the vertical resolution by a factor of 2.

Fixes an issue during merging in macrotiles which have three or more overlapping sources.
