### PR TITLE
Refactor terrain example to use only terrainSource

### DIFF
--- a/website/examples/terrain/example.html
+++ b/website/examples/terrain/example.html
@@ -45,10 +45,6 @@
                     terrainSource: {
                         type: 'raster-dem',
                         url: 'https://tiles.mapterhorn.com/tilejson.json',
-                    },
-                    hillshadeSource: {
-                        type: 'raster-dem',
-                        url: 'https://tiles.mapterhorn.com/tilejson.json',
                     }
                 },
                 layers: [
@@ -60,7 +56,7 @@
                     {
                         id: 'hills',
                         type: 'hillshade',
-                        source: 'hillshadeSource',
+                        source: 'terrainSource',
                         paint: { 'hillshade-shadow-color': '#473B24' }
                     }
                 ],


### PR DESCRIPTION
In case it's useful, the same source can be used for both terrain and hillshade. 

Just removed hillshadeSource and updated hills layer to use terrainSource.