### PR TITLE
Fix nodata handling during merge

### DIFF
--- a/pipelines/aggregation_merge.py
+++ b/pipelines/aggregation_merge.py
@@ -106,6 +106,7 @@ def merge(filepath):
                             boundary_tile &= eroded.astype(bool)
                             
                             if 1 in boundary_tile:
+                                merged_tile[merged_tile == -9999] = 0
                                 truncate = 4
                                 sigma = int(overlap / truncate) - 1
                                 boundary_tile_blurred = ndimage.gaussian_filter(boundary_tile.astype(float), sigma=sigma, truncate=truncate)


### PR DESCRIPTION
Fixes #93 

While we started to keep track of boundary pixels in https://github.com/mapterhorn/mapterhorn/pull/104/files#r2476740464, there can still be an issue if close to a NODATA boundary in a distance smaller then the blur radius we have a boundary between two data sets. This happens for example near the Balearic Islands.
The solution proposed here is to set nodata to zero before the blurring/merging. Like that things get a lot simpler and since glo30 covers the entire land mass, we should only get nodata in oceans.