### PR TITLE
Add mirror script

### DIFF
--- a/distribution/mirrors.json
+++ b/distribution/mirrors.json
@@ -1,0 +1,10 @@
+{
+    "Hetzner (DE)": {
+        "homepage": "https://nbg1.your-objectstorage.com/mapterhorn/index.html",
+        "base_url": "https://nbg1.your-objectstorage.com/mapterhorn/"
+    },
+    "Source Coop (US)": {
+        "homepage": "https://source.coop/mapterhorn/mapterhorn",
+        "base_url": "https://data.source.coop/mapterhorn/mapterhorn/"
+    }
+}

--- a/pipelines/mirror.py
+++ b/pipelines/mirror.py
@@ -7,7 +7,7 @@ import subprocess
 SILENT = False
 CHUNKSIZE = 1_000_000_000
 TMPDIR = '/tmp/'
-PROCESSES = 32
+PROCESSES = 16
 
 def run_command(command, silent=True):
     if not silent:
@@ -24,6 +24,8 @@ def run_command(command, silent=True):
 
 def get_file_size(url):
     r = requests.head(url)
+    if r.headers.get('Content-Encoding', None) == 'gzip':
+        return CHUNKSIZE
     return int(r.headers.get('Content-Length', 0))
 
 def download_range(url, start, end, filepath):
@@ -33,14 +35,14 @@ def download_range(url, start, end, filepath):
         print('out:', out)
         print('err:', err)
 
-def create_multipart_upload(bucket, key, region):
+def create_multipart_upload(bucket, key, region, endpoint):
     '''
     Requires the following env variables:
     $ export AWS_ACCESS_KEY_ID=MY_KEY
     $ export AWS_SECRET_ACCESS_KEY=MY_SECRET
     '''
     
-    command = f'aws s3api create-multipart-upload --bucket {bucket} --key {key} --region {region}'
+    command = f'aws s3api create-multipart-upload --bucket {bucket} --key {key} --region {region} --endpoint "{endpoint}"'
     out, err = run_command(command, silent=SILENT)
     if err != '':
         print('err:', err)
@@ -48,14 +50,14 @@ def create_multipart_upload(bucket, key, region):
     data = json.loads(out)
     return data.get('UploadId', None)
 
-def upload_part(bucket, key, part_number, filepath, upload_id, region):
+def upload_part(bucket, key, part_number, filepath, upload_id, region, endpoint):
     '''
     Requires the following env variables:
     $ export AWS_ACCESS_KEY_ID=MY_KEY
     $ export AWS_SECRET_ACCESS_KEY=MY_SECRET
     '''
 
-    command = f'aws s3api upload-part --bucket {bucket} --key {key} --part-number {part_number} --body {filepath} --upload-id "{upload_id}" --region {region}'
+    command = f'aws s3api upload-part --bucket {bucket} --key {key} --part-number {part_number} --body {filepath} --upload-id "{upload_id}" --region {region} --endpoint "{endpoint}"'
     out, err = run_command(command, silent=SILENT)
     if err != '':
         print('err:', err)
@@ -63,7 +65,7 @@ def upload_part(bucket, key, part_number, filepath, upload_id, region):
     data = json.loads(out)
     return data.get('ETag', None)
 
-def complete_multipart_upload(bucket, key, upload_id, parts, region):
+def complete_multipart_upload(bucket, key, upload_id, parts, region, endpoint):
     '''
     Requires the following env variables:
     $ export AWS_ACCESS_KEY_ID=MY_KEY
@@ -71,20 +73,30 @@ def complete_multipart_upload(bucket, key, upload_id, parts, region):
     '''
         
     parts = {'Parts': parts}
-    command = f'aws s3api complete-multipart-upload --bucket {bucket} --key {key} --upload-id "{upload_id}" --multipart-upload \'{json.dumps(parts)}\' --region {region}'
-    out, err = run_command(command, silent=SILENT)
+    command = f'aws s3api complete-multipart-upload --bucket {bucket} --key {key} --upload-id "{upload_id}" --multipart-upload \'{json.dumps(parts)}\' --region {region} --endpoint "{endpoint}"'
+    _, err = run_command(command, silent=SILENT)
     if err != '':
         print('err:', err)
         raise Exception(err)
 
-def process_range(url, start, end, bucket, key, part_number, part_filepath, upload_id, region):
-    download_range(url, start, end, part_filepath)
-    etag = upload_part(bucket, key, part_number, part_filepath, upload_id, region)
-    os.remove(part_filepath)
-    return {'ETag': etag, 'PartNumber': part_number}
+def process_range(url, start, end, bucket, key, part_number, part_filepath, upload_id, region, endpoint):
+    retries = 0
+    max_retries = 3
+    while True:
+        try:
+            download_range(url, start, end, part_filepath)
+            etag = upload_part(bucket, key, part_number, part_filepath, upload_id, region, endpoint)
+            os.remove(part_filepath)
+            return {'ETag': etag, 'PartNumber': part_number}
+        except Exception as e:
+            if retries < max_retries:
+                print(f'retries={retries}, max_retries={max_retries}, err={e}')
+                retries += 1
+            else:
+                raise Exception(f'max retries reached, err={e}')
 
-def mirror_http_resource_to_s3(url, bucket, key, region, filename):  
-    upload_id = create_multipart_upload(bucket, key, region)
+def mirror_http_resource_to_s3(url, bucket, key, region, endpoint, filename):  
+    upload_id = create_multipart_upload(bucket, key, region, endpoint)
     print('upload_id', upload_id)
 
     full_size = get_file_size(url)
@@ -97,7 +109,7 @@ def mirror_http_resource_to_s3(url, bucket, key, region, filename):
     argument_tuples = []
     while start < full_size:
         part_filepath = f'{TMPDIR}/{filename}.part{part_number}'
-        argument_tuples.append((url, start, end, bucket, key, part_number, part_filepath, upload_id, region))        
+        argument_tuples.append((url, start, end, bucket, key, part_number, part_filepath, upload_id, region, endpoint))        
 
         part_number += 1
         start += CHUNKSIZE
@@ -107,7 +119,7 @@ def mirror_http_resource_to_s3(url, bucket, key, region, filename):
     with Pool(PROCESSES) as pool:
         parts = pool.starmap(process_range, argument_tuples, chunksize=1)
     
-    complete_multipart_upload(bucket, key, upload_id, parts, region)
+    complete_multipart_upload(bucket, key, upload_id, parts, region, endpoint)
 
 def get_filenames(mirror_base_url):
     filenames = []
@@ -118,7 +130,7 @@ def get_filenames(mirror_base_url):
     mapterhorn_data = json.loads(mapterhorn_r.text)
     mapterhorn_name_to_md5sum = {item['name']: item['md5sum'] for item in mapterhorn_data['items']}
 
-    mirror_r = requests.get(f'{mirror_base_url}/download_urls.json')
+    mirror_r = requests.get(f'{mirror_base_url}download_urls.json')
     mirror_name_to_md5sum = {}
     if mirror_r.status_code == 200:
         mirror_data = json.loads(mirror_r.text)
@@ -130,20 +142,37 @@ def get_filenames(mirror_base_url):
         else:
             if mapterhorn_name_to_md5sum[name] != mirror_name_to_md5sum[name]:
                 filenames.append(name)
-    
-    filenames += [
-        'attribution.json',
-        'download_urls.json'
-    ]
 
     return filenames
 
-if __name__ == '__main__':
-    mirror_base_url = 'https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/mapterhorn/'
+def main():
+
+    # Hetzner
+    mirror_base_url = 'https://nbg1.your-objectstorage.com/mapterhorn/'
+    region = 'nbg1'
+    bucket = 'mapterhorn'
+    endpoint = 'https://nbg1.your-objectstorage.com/'
+    prefix = '' 
+
+    # # Source Coop
+    # mirror_base_url = 'https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/mapterhorn/mapterhorn/'
+    # region = 'us-west-2'
+    # bucket = 'us-west-2.opendata.source.coop'
+    # endpoint = f'https://s3.{region}.amazonaws.com'
+    # prefix = 'mapterhorn/mapterhorn/'
+
     filenames = get_filenames(mirror_base_url)
+
+    if len(filenames) == 0:
+        print('nothing to do...')
+        return
+    
+    filenames += ['attribution.json', 'download_urls.json']
+
     for filename in filenames:
-        url = F'https://download.mapterhorn.com/{filename}'
-        bucket = 'us-west-2.opendata.source.coop'
-        key = f'mapterhorn/{filename}'
-        region = 'us-west-2'
-        mirror_http_resource_to_s3(url, bucket, key, region, filename)
+        url = f'https://download.mapterhorn.com/{filename}'
+        key = f'{prefix}{filename}'
+        mirror_http_resource_to_s3(url, bucket, key, region, endpoint, filename)
+
+if __name__ == '__main__':
+    main()

--- a/pipelines/mirrorstatus.py
+++ b/pipelines/mirrorstatus.py
@@ -1,0 +1,61 @@
+import requests
+import json
+import time
+
+import upload
+
+def get_size_by_filename():
+    size_by_filename = {}
+    r = requests.get('https://download.mapterhorn.com/download_urls.json')
+    data = json.loads(r.text)
+    for item in data['items']:
+        size_by_filename[item['name']] = item['size']
+    return size_by_filename
+
+def get_mirrors():
+    r = requests.get('https://raw.githubusercontent.com/mapterhorn/mapterhorn/refs/heads/main/distribution/mirrors.json')
+    return json.loads(r.text)
+
+def main():   
+    last_update = int(time.time())
+
+    size_by_filename = get_size_by_filename()
+    mirrors = get_mirrors()
+
+    items = {}
+
+    for filename in size_by_filename:
+        print(filename)
+        items[filename] = []
+        for mirror_name, mirror in mirrors.items():
+            url = f'{mirror["base_url"]}{filename}'
+            r = requests.head(url, timeout=5)
+            mirror_size = int(r.headers.get('Content-Length', 0))
+            if mirror_size == size_by_filename[filename]:
+                print(f'  found matching filesize on {mirror_name}')
+                items[filename].append(mirror_name)
+            else:
+                print(f'  did not find a matching filesize on {mirror_name}: primary={size_by_filename[filename]}, mirror={mirror_size}')
+    
+    mirrorstatus = {
+        'last_update': last_update,
+        'mirrors': mirrors,
+        'items': items,
+    }
+
+    print(json.dumps(mirrorstatus, indent=2))
+
+    with open('bundle-store/mirrorstatus.json', 'w') as f:
+        json.dump(mirrorstatus, f, indent=2)
+
+    directory = 'bundle-store'
+    filename = 'mirrorstatus.json'
+    key = filename
+    bucket = 'mapterhorn'
+    region = 'auto'
+    endpoint = 'https://5521f1c60beed398e82b05eabc341142.r2.cloudflarestorage.com/'
+    upload.upload_local_resource_to_s3(directory, filename, bucket, key, region, endpoint)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipelines/verify_upload.py
+++ b/pipelines/verify_upload.py
@@ -1,0 +1,52 @@
+import json
+import requests
+from multiprocessing import Pool
+
+import utils
+
+SILENT=True
+PROCESSES = 32
+
+def has_expected_size(url, expected_size):
+    r = requests.head(url)
+    actual_size = int(r.headers.get('Content-Length', -1))
+    return actual_size == expected_size
+
+def has_expected_md5sum(url, expected_md5sum):
+    command = f'wget {url} -O - | md5sum'
+    out, _ = utils.run_command(command, silent=SILENT)
+    parts = out.split(' ')
+    assert len(parts) > 0
+    return parts[0] == expected_md5sum
+
+def has_expected_size_and_md5sum(url, expected_size, expected_md5sum):
+    if not has_expected_size(url, expected_size):
+        return False
+    if not has_expected_md5sum(url, expected_md5sum):
+        return False
+    return True
+
+def print_check(url, expected_size, expected_md5sum):
+    if has_expected_size_and_md5sum(url, expected_size, expected_md5sum):
+        print(url, 'good')
+    else:
+        print(url, 'bad')
+
+def main():
+    r = requests.get('https://download.mapterhorn.com/download_urls.json')
+    data = json.loads(r.text)
+    
+    base_url = 'https://download.mapterhorn.com/' # Cloudflare
+    # base_url = 'https://nbg1.your-objectstorage.com/mapterhorn/' # Hetzner
+    # base_url = 'https://data.source.coop/mapterhorn/mapterhorn/' # Source Coop
+
+    argument_tuples = []
+    for item in data['items']:
+        url = f'{base_url}{item['name']}'
+        argument_tuples.append((url, item['size'], item['md5sum']))
+
+    with Pool(PROCESSES) as pool:
+        pool.starmap(print_check, argument_tuples, chunksize=1)
+
+if __name__ == '__main__':
+    main()

--- a/website/data-access/index.html
+++ b/website/data-access/index.html
@@ -74,11 +74,6 @@
         TileJSON endpoint: <code>https://tiles.mapterhorn.com/tilejson.json</code>
     </p>
 
-    <h2 id="bulk-download">Bulk Download</h2>
-    <p> For a full list of PMTiles download URLs in JSON format see <a
-            href="https://download.mapterhorn.com/download_urls.json">download_urls.json</a>.
-    </p>
-
     <h2 id="area-extracts">Area Extracts</h2>
     <p>
         Download Mapterhorn data extracts for a limited area.
@@ -139,16 +134,41 @@
         Tip: Add the flag <code>--dry-run</code> to get the total extract size before starting the actual download.
     </p>
 
+    <h2 id="mirrors">Mirrors</h2>
+    <p>
+        Mapterhorn's PMTiles are available on multiple mirrors:
+    </p>
+
+    <p>
+        <span id="mirror-list"></span>
+    </p>
+
+    <p>
+        For the current update status of the mirrors see <a
+            href="https://download.mapterhorn.com/mirrorstatus.json">mirrorstatus.json</a>.
+    </p>
+
     <h2 id="file-list">File List</h2>
-    <p>Total PMTiles size: <span id="total_size"></span>.</p>
+    <p>
+        For a full list of PMTiles download URLs in JSON format see <a
+            href="https://download.mapterhorn.com/download_urls.json">download_urls.json</a>.
+    </p>
+    <p>
+        Total PMTiles size: <span id="total-size"></span>.
+    </p>
+    <p>
+        Total number of PMTiles files: <span id="total-pmtiles-count"></span>.
+    </p>
+
     <table>
         <thead>
             <tr>
                 <th>name</th>
-                <th>zoom</th>
+                <th class="hide-mobile">zoom</th>
                 <th>size</th>
                 <th class="hide-mobile">md5sum</th>
                 <th>coverage</th>
+                <th>mirrors</th>
             </tr>
         </thead>
         <tbody id="table-body">
@@ -170,6 +190,10 @@
         const buildList = async () => {
             const request = await fetch('https://download.mapterhorn.com/download_urls.json');
             const data = await request.json();
+
+            const mirrorRequest = await fetch('https://download.mapterhorn.com/mirrorstatus.json')
+            const mirrorstatus = await mirrorRequest.json();
+
             const version = `v${data['version']}`;
             const items = [
                 ...data['items'].filter(item => item['name'] === 'planet.pmtiles'),
@@ -178,6 +202,12 @@
 
             const versionSpan = document.getElementById('version');
             versionSpan.textContent = version;
+
+            const totalPMTilesCountSpan = document.getElementById('total-pmtiles-count');
+            totalPMTilesCountSpan.textContent = data['items'].length;
+
+            const mirrorListSpan = document.getElementById('mirror-list');
+            mirrorListSpan.innerHTML = Object.entries(mirrorstatus['mirrors']).map(([name, mirror]) => `<a href="${mirror['homepage']}">${name}</a>`).join('<br>');
 
             const tableBody = document.getElementById('table-body');
 
@@ -193,6 +223,7 @@
                 tr.appendChild(nameTd);
 
                 const zoomTd = document.createElement('td');
+                zoomTd.classList.add('hide-mobile')
                 zoomTd.textContent = `z${item['min_zoom']}-z${item['max_zoom']}`;
                 tr.appendChild(zoomTd);
 
@@ -202,7 +233,7 @@
 
                 const md5Td = document.createElement('td');
                 md5Td.classList.add('hide-mobile');
-                md5Td.textContent = item['md5sum'];
+                md5Td.textContent = item['md5sum'].slice(0, 8) + '...';
                 tr.appendChild(md5Td);
 
                 const coverageTd = document.createElement('td');
@@ -219,10 +250,18 @@
                 }
                 tr.appendChild(coverageTd);
 
+                const mirrorTd = document.createElement('td');
+                const parts = [`<a href="${item['url']}">Primary</a>`];
+                for (const name of mirrorstatus['items'][item['name']]) {
+                    parts.push(`<a href="${mirrorstatus['mirrors'][name]['base_url']}${item['name']}">${name}</a>`);
+                }
+                mirrorTd.innerHTML = parts.join('<br>');
+                tr.appendChild(mirrorTd);
+
                 tableBody.appendChild(tr);
                 totalSize += item['size'];
             }
-            const sizeSpan = document.getElementById('total_size');
+            const sizeSpan = document.getElementById('total-size');
             sizeSpan.textContent = `${(totalSize / Math.pow(1024, 4)).toFixed(1)} TiB`;
         }
         buildList();


### PR DESCRIPTION
Adds a script to mirror the PMTiles files to a third-party S3 compatible storage provider.
It downloads the files in chunks and uploads them also in chunks, so one does not need to download the full file and give up half a terabyte of disk space for the mirroring.