### PR TITLE
spelling fixes; mention wget as a requirement

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -179,6 +179,7 @@ With this convention we can limit the total file size to roughly 1 terabyte assu
 - uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - just: https://github.com/casey/just?tab=readme-ov-file#installation
 - aws cli: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+- wget
 
 ## Debug Pipeline
 

--- a/website/index.html
+++ b/website/index.html
@@ -33,7 +33,7 @@
     <ul>
         <li>✅ Create a source catalog that lists available open digital elevation models and their licenses</li>
         <li>✅ Write a pipeline to aggregate digital elevation models with different resolutions</li>
-        <li>✅ Apply the pipepline to a global low-resolution and a local high-resolution dataset</li>
+        <li>✅ Apply the pipeline to a global low-resolution and a local high-resolution dataset</li>
         <li>✅ Distribute the aggregated digital elevation model as PMTiles</li>
         <li>✅ Write documentation for contributors explaining the pipeline</li>
         <li>✅ Write documentation for end-users with examples</li>


### PR DESCRIPTION
It looks like curl may also be a requirement in the upload pipeline?

On my mac I was missing `wget` so had to install it before I could run the source pipeline. 