### PR TITLE
Create tar-store directory before attempting to access it

### DIFF
--- a/pipelines/source_create_tarball.py
+++ b/pipelines/source_create_tarball.py
@@ -12,7 +12,8 @@ def main():
     else:
         print('Not enough arguments. Usage: source_create_tarball.py {{source}}')
         exit()
-    
+
+    utils.create_folder('tar-store/')
     checksum = None
     with open(f'tar-store/{source}.tar', 'wb') as f:
         writer = utils.HashWriter(f)


### PR DESCRIPTION
Fix to resolve an error encountered when running a pipeline.

```python
creating tarball for usgsned13...
Traceback (most recent call last):
  File "~/mapterhorn/pipelines/source_create_tarball.py", line 36, in <module>
    main()
    ~~~~^^
  File "~/mapterhorn/pipelines/source_create_tarball.py", line 17, in main
    with open(f'tar-store/{source}.tar', 'wb') as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'tar-store/usgsned13.tar'
error: Recipe `default` failed on line 7 with exit code 1
```