### PR TITLE
Fix antimeridian handling

### DIFF
--- a/pipelines/aggregation_run.py
+++ b/pipelines/aggregation_run.py
@@ -20,7 +20,7 @@ def run(filepath):
     utils.run_command(f'touch {filepath.replace("-aggregation.csv", "-aggregation.done")}')
     print(f'{item} end')
 
-def main():    
+def main():
     aggregation_ids = utils.get_aggregation_ids()
     aggregation_id = aggregation_ids[-1]
 

--- a/pipelines/source_bounds.py
+++ b/pipelines/source_bounds.py
@@ -5,6 +5,8 @@ import math
 import rasterio
 from rasterio.warp import transform_bounds
 
+import utils
+
 def main():
     source = None
     if len(sys.argv) > 1:
@@ -23,6 +25,13 @@ def main():
             if src.crs is None:
                 raise ValueError(f'crs not defined on {filepath}')
             left, bottom, right, top = transform_bounds(src.crs, 'EPSG:3857', *src.bounds)
+
+            if right - left > 0.9 * 2 * utils.X_MAX_3857:
+                # probably the image crosses the antimeridian
+                # in this case rasterio.warp.transform_bounds mixes up left and right
+                # and we need to flip it back
+                left, right = right, left
+
             for num in [left, bottom, right, top]:
                 if not math.isfinite(num):
                     raise ValueError(f'Number in bounds is not finite. src.bounds={src.bounds} src.crs={src.crs} bounds={(left, bottom, right, top)}')

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -7,6 +7,7 @@ import hashlib
 
 import numpy as np
 
+from rasterio.warp import transform_bounds
 import mercantile
 import imagecodecs
 from pmtiles.tile import zxy_to_tileid, tileid_to_zxy, TileType, Compression
@@ -15,6 +16,8 @@ from pmtiles.writer import Writer
 macrotile_z = 12
 macrotile_buffer_3857 = 150
 num_overviews = 6
+
+X_MIN_3857, _, X_MAX_3857, __ = transform_bounds('EPSG:4326', 'EPSG:3857', -180, 0, 180, 0)
 
 def run_command(command, silent=True):
     if not silent:


### PR DESCRIPTION
While working on the USGS dataset I noticed that it triggered rebuilding aggregation items in Poland.
This was a bit surprising since the data only covers US territories. I notice then that there are bands across the entire world from left to right. This comes from source items at the antimeridian. The code was not handling the situation correctly where the left corner of a source image would be in the range East 180 - delta to 180 deg while the right corner would be in the range W 180 to 180 - delta degree for a small delta.
The global Copernicus dataset has also some source tifs that were wrongly handled, so I guess we need to run a fresh planet build now...
