### PR TITLE
Enhance source download process

### DIFF
--- a/pipelines/source_download.py
+++ b/pipelines/source_download.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 
 def download_all_files(urls, source_dir):
-    '''
+    """
     Download all files using wget with automatic resume support.
 
     Args:
         urls: List of URLs to download.
         source_dir: Directory to save downloaded files.
-    '''
+    """
 
     input_file = f'{source_dir}/.download_urls.txt'
     expected_files = []
@@ -50,7 +50,7 @@ def download_all_files(urls, source_dir):
 
 
 def parse_file_list(file_list_path):
-    '''
+    """
     Parse a file_list.txt and extract URLs.
 
     Args:
@@ -62,7 +62,7 @@ def parse_file_list(file_list_path):
     Raises:
         FileNotFoundError: If the file_list.txt does not exist.
         ValueError: If no URLs are found in the file.
-    '''
+    """
     if not os.path.exists(file_list_path):
         raise FileNotFoundError(f'File list not found: {file_list_path}')
 
@@ -83,7 +83,7 @@ def parse_file_list(file_list_path):
 
 
 def main():
-    '''
+    """
     Main entry point for the source download script.
 
     Command-line arguments:
@@ -95,7 +95,7 @@ def main():
 
     Examples:
         uv run python source_download.py at1
-    '''
+    """
     if len(sys.argv) != 2:
         print('wrong number of arguments: source_download.py source')
         sys.exit(1)


### PR DESCRIPTION
While testing new data sources locally, an issue was encountered that after some time revealed one of the files had failed to download. To help prevent this, changes here will log more status information and log errors so that users can precisely identify any problems during the download process. ~~The option to show a visualization of download progress was added.~~

_Note: This was only tested with `wget2`_

## Test
An invalid file was added to the `au5` data source list and then the download process run to show the output:

<img width="1187" height="353" alt="Screenshot From 2026-01-09 19-46-37" src="https://github.com/user-attachments/assets/905feba5-94cc-4595-9be5-6d3f6877615d" />

_Current process appears to succeed, and the pipeline will continue_

<img width="951" height="363" alt="fail" src="https://github.com/user-attachments/assets/29013966-333e-4b87-bd00-7c88ef7f9626" />

_New process exits the pipeline and indicates which files failed_
