### PR TITLE
Add support for downloads with bearer tokens

### DIFF
--- a/pipelines/source_download.py
+++ b/pipelines/source_download.py
@@ -1,21 +1,34 @@
 import utils
 import sys
+import os
 
-def download_from_internet(source):
+def download_from_internet(source, token_env_var=None):
     urls = []
     with open(f'../source-catalog/{source}/file_list.txt') as f:
         urls = [l.strip() for l in f.readlines()]
+
+    token = None
+    if token_env_var:
+        token = os.environ.get(token_env_var)
+        if token:
+            print(f'Using bearer token from environment variable: {token_env_var}')
+        else:
+            print(f'Warning: Environment variable {token_env_var} not found, downloading without token')
+
     j = 0
     for url in urls:
         j += 1
         if j % 100 == 0:
             print(f'downloaded {j} / {len(urls)}')
 
-        command = f'cd source-store/{source} && wget --no-verbose --continue "{url}"'
+        auth_header = f'--header="Authorization: Bearer {token}" ' if token else ''
+        command = f'cd source-store/{source} && wget {auth_header}--progress=bar:force --continue "{url}"'
         utils.run_command(command, silent=False)
 
 def main():
     source = None
+    token_env_var = None
+
     if len(sys.argv) > 1:
         source = sys.argv[1]
         print(f'downloading {source}...')
@@ -23,8 +36,11 @@ def main():
         print('source argument missing...')
         exit()
 
+    if len(sys.argv) > 2:
+        token_env_var = sys.argv[2]
+
     utils.create_folder( f'source-store/{source}/')
-    download_from_internet(source)
+    download_from_internet(source, token_env_var)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Enables downloads to include an optional bearer token which is needed to download data from certain services. This change is utilized in: https://github.com/mapterhorn/mapterhorn/pull/192