### PR TITLE
Added cloud optimized geo-tiffs

### DIFF
--- a/pipelines/aggregation_geotiff.py
+++ b/pipelines/aggregation_geotiff.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+from glob import glob
+
+import mercantile
+
+import utils
+
+
+def main(filepath: str) -> None:
+    _, aggregation_id, filename = filepath.split("/")
+
+    z, x, y, child_z = [
+        int(a) for a in filename.removesuffix("-aggregation.csv").split("-")
+    ]
+
+    tmp_folder = f"aggregation-store/{aggregation_id}/{z}-{x}-{y}-{child_z}-tmp"
+
+    geotiff_done_filepath = f"{tmp_folder}/geotiff-done"
+    if os.path.isfile(geotiff_done_filepath):
+        print(f"geotiff {filename} already done...")
+        return
+
+    merge_done = os.path.isfile(f"{tmp_folder}/merge-done")
+    if not merge_done:
+        raise AssertionError(f"merge not done yet for {filepath}...")
+
+    num_tiff_files = len(glob(f"{tmp_folder}/*.tiff"))
+    tiff_filepath = f"{tmp_folder}/{num_tiff_files - 1}-3857.tiff"
+    cog_filepath = f"{tmp_folder}/{num_tiff_files - 1}-3857-cog.tiff"
+    left, bottom, right, top = mercantile.xy_bounds(mercantile.Tile(x=x, y=y, z=z))
+
+    command = f"gdal_translate {tiff_filepath} {cog_filepath}"
+    command += f" -projwin {left} {top} {right} {bottom}" # removes buffer
+    command += " -of COG"
+    command += " -co BIGTIFF=IF_NEEDED -co ADD_ALPHA=YES -co OVERVIEWS=NONE"
+    command += " -co BLOCKSIZE=512 -co COMPRESS=LERC -co MAX_Z_ERROR=0.001"
+    out, err = utils.run_command(command)
+    if err.strip() != "":
+        raise IOError(f"gdal_translate failed for {tiff_filepath}:\n{out}\n{err}")
+
+    out_folder = utils.get_geotiff_folder(x, y, z)
+    utils.create_folder(out_folder)
+    out_filepath = f"{out_folder}/{z}-{x}-{y}-{child_z}.tif"
+    shutil.move(src=cog_filepath, dst=out_filepath)
+    utils.run_command(f"touch {geotiff_done_filepath}")

--- a/pipelines/combine_geotiffs.py
+++ b/pipelines/combine_geotiffs.py
@@ -1,0 +1,62 @@
+from functools import cache
+
+import mercantile
+
+import utils
+from utils_geotiff import find_existing_geo_tiffs, get_child_z, get_tile
+
+
+def find_sources_for_zoom(zoom: int, tile_paths: list[str]) -> list[str]:
+    tile_paths_for_zoom = [p for p in tile_paths if get_child_z(p) == zoom]
+    paths_by_tile = {get_tile(path): path for path in tile_paths_for_zoom}
+    existing_zooms = {t.z for t in paths_by_tile.keys()}
+    if len(existing_zooms) == 1:
+        # All tiles have the same zoom
+        return tile_paths_for_zoom
+
+    # Strategy:
+    # - If a tile has data for its full extent, include it
+    # - If it only has date for some parts it covers, include the subparts
+
+    @cache
+    def is_complete(tile_path: str) -> bool:
+        tile = get_tile(tile_path)
+        possible_children = mercantile.children(tile)
+        existing_children = [c for c in possible_children if c in paths_by_tile]
+        if not existing_children:
+            return True
+        all_present = len(existing_children) == len(possible_children)
+        all_complete = all(is_complete(paths_by_tile[c]) for c in existing_children)
+        return all_present and all_complete
+
+    return [path for path in tile_paths_for_zoom if is_complete(path)]
+
+
+def create_combined(zoom, source_paths: list[str]):
+    target_prefix = f"geotiff-store/z{zoom}"
+    target_path = f"{target_prefix}.vrt"
+    input_file_list_path = f"{target_prefix}-sources.txt"
+    with open(input_file_list_path, "w") as f:
+        f.write("\n".join(source_paths))
+    command = f"gdalbuildvrt -overwrite -input_file_list {input_file_list_path} {target_path}"
+    out, err = utils.run_command(command)
+    if err.strip() != "":
+        raise IOError(f"gdalbuildvrt failed for {target_path}:\n{out}\n{err}")
+    print(f"Created {target_path}")
+
+
+def main():
+    print("Combining geotiff of same zoom level...")
+    paths = find_existing_geo_tiffs()
+    zoom_levels = sorted({get_child_z(p) for p in paths})
+    print(f"Creating combined file for each level: {zoom_levels}")
+
+    for z in zoom_levels:
+        source_paths = find_sources_for_zoom(z, paths)
+        print(f"Found {len(source_paths)} sources for zoom {z}")
+
+        create_combined(z, source_paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/downsampling_geotiff.py
+++ b/pipelines/downsampling_geotiff.py
@@ -1,0 +1,101 @@
+import os
+import shutil
+from multiprocessing import Pool
+
+import mercantile
+from mercantile import Tile
+from rasterio.crs import defaultdict
+
+import utils
+import aggregation_reproject
+from utils_geotiff import find_existing_geo_tiffs, get_child_z, get_tile
+
+
+def new_tile_path(tile: Tile, source_paths: list[str]) -> str:
+    child_z = determine_new_child_z(tile, source_paths)
+    folder = utils.get_geotiff_folder(tile.x, tile.y, tile.z)
+    return f"{folder}/{tile.z}-{tile.x}-{tile.y}-{child_z}.tif"
+
+
+def determine_new_child_z(tile: Tile, source_paths: list[str]) -> int:
+    source_max_child_z = max(get_child_z(path) for path in source_paths)
+    return min(source_max_child_z, tile.z + 6)
+
+
+def find_tiles_to_create(tile_paths: list[str]) -> list[tuple[Tile, list[str]]]:
+    tiles = {get_tile(path): path for path in tile_paths}
+    max_z = max(tile.z for tile in tiles.keys())
+
+    tiles_to_create: list[tuple[Tile, list[str]]] = []
+    for z in range(max_z, 0, -1):
+        tiles_to_create_for_zoom = defaultdict(list)
+        for tile, path in tiles.items():
+            if tile.z != z:
+                continue
+            parent = mercantile.parent(tile)
+            if parent not in tiles:
+                tiles_to_create_for_zoom[parent].append(path)
+
+        new_tiles = {
+            tile: new_tile_path(tile, source_paths)
+            for tile, source_paths in tiles_to_create_for_zoom.items()
+        }
+
+        tiles |= new_tiles
+        tiles_to_create += tiles_to_create_for_zoom.items()
+
+    return tiles_to_create
+
+
+def create_tile(tile: Tile, source_paths: list[str]) -> None:
+    print(f"started {tile}")
+    child_z = determine_new_child_z(tile, source_paths)
+    target_path = new_tile_path(tile, source_paths)
+    target_prefix = target_path.removesuffix(".tif")
+
+    resolution = aggregation_reproject.get_resolution(child_z)
+    left, bottom, right, top = mercantile.xy_bounds(tile)
+
+    mosaic_path = f"{target_prefix}.mosaic.vrt"
+    command = f"gdal raster mosaic {' '.join(source_paths)} {mosaic_path}"
+    command += " --resolution highest"
+    command += " --overwrite"
+    command += " --src-nodata -9999 --dst-nodata -9999"
+    out, err = utils.run_command(command)
+    if err.strip() != "":
+        print(f"gdal raster mosaic failed for {target_path}:\n{out}\n{err}")
+        return
+
+    target_path_tmp = f"{target_prefix}.tmp.tif"
+    command = f"gdalwarp {mosaic_path} {target_path_tmp}"
+    command += " -r average"
+    command += f" -te {left} {bottom} {right} {top}"
+    command += f" -tr {resolution} {resolution}"
+    command += " -of COG"
+    command += " -co BIGTIFF=IF_NEEDED -co ADD_ALPHA=YES -co OVERVIEWS=NONE"
+    command += " -co BLOCKSIZE=512 -co COMPRESS=LERC -co MAX_Z_ERROR=0.001"
+    out, err = utils.run_command(command)
+    if err.strip() != "":
+        raise IOError(f"gdalwarp failed for {target_path}:\n{out}\n{err}")
+
+    os.remove(mosaic_path)
+    shutil.move(target_path_tmp, target_path)
+    print(f"finished {target_path}")
+
+
+def main():
+    print("Computing merged and downsampled tiles to create...")
+    tiles = find_existing_geo_tiffs()
+    tiles_to_create = find_tiles_to_create(tiles)
+
+    print(f"Creating {len(tiles_to_create)} tiles by merging and downsampling.")
+    levels = sorted({t.z for t, _ in tiles_to_create}, reverse=True)
+    for level in levels:
+        argument_tuples = [(tile, p) for tile, p in tiles_to_create if tile.z == level]
+        print(f"Processing z={level} with {len(argument_tuples)} tiles.")
+        with Pool(processes=16) as pool:
+            pool.starmap(create_tile, argument_tuples, chunksize=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -152,13 +152,20 @@ def get_dirty_aggregation_filenames(current_aggregation_id, last_aggregation_id)
     return dirty_filenames
 
 def get_pmtiles_folder(x, y, z):
+    return get_target_folder(x, y, z, 'pmtiles-store')
+
+def get_geotiff_folder(x, y, z):
+    return get_target_folder(x, y, z, 'geotiff-store')
+
+def get_target_folder(x: int, y: int, z: int, base_path: str) -> str:
     if z < 7:
-        return 'pmtiles-store'
+        return base_path
+
     if z == 7:
-        return f'pmtiles-store/{z}-{x}-{y}'
-    else:
-        parent = mercantile.parent(mercantile.Tile(x=x, y=y, z=z), zoom=7)
-        return f'pmtiles-store/{parent.z}-{parent.x}-{parent.y}'
+        return f'{base_path}/{z}-{x}-{y}'
+
+    parent = mercantile.parent(mercantile.Tile(x=x, y=y, z=z), zoom=7)
+    return f'{base_path}/{parent.z}-{parent.x}-{parent.y}'
 
 # group source items by maxzoom and source
 def get_grouped_source_items(filepath):

--- a/pipelines/utils_geotiff.py
+++ b/pipelines/utils_geotiff.py
@@ -1,0 +1,41 @@
+from glob import glob
+from typing import Optional
+
+from mercantile import Tile
+
+
+def find_existing_geo_tiffs() -> list[str]:
+    geo_tiff_paths = glob("geotiff-store/**/*.tif", recursive=True)
+    tiles = []
+    for path in geo_tiff_paths:
+        if get_zxy_child_z_if_well_formed(path) is None:
+            print(f"Ignoring geotiff: {path}")
+        else:
+            tiles.append(path)
+    return tiles
+
+
+def get_tile(path: str) -> Tile:
+    z, x, y, _ = get_zxy_child_z(path)
+    return Tile(x=int(x), y=int(y), z=int(z))
+
+
+def get_child_z(path: str) -> int:
+    return get_zxy_child_z(path)[3]
+
+
+def get_zxy_child_z_if_well_formed(path: str) -> Optional[tuple[int, int, int, int]]:
+    filename = path.split("/")[-1].removesuffix(".tif")
+    parts = filename.split("-")
+    if len(parts) != 4 or not all(part.isdigit() for part in parts):
+        return None
+
+    z, x, y, child_z = map(int, parts)
+    return z, x, y, child_z
+
+
+def get_zxy_child_z(path: str) -> tuple[int, int, int, int]:
+    parts = get_zxy_child_z_if_well_formed(path)
+    if parts is None:
+        raise ValueError(f"Could not parse z, x, y, child_z from path: {path}")
+    return parts


### PR DESCRIPTION
Hi! Thanks for the work on creating a merged DEM. I added the ability to generate cloud-optimized GeoTiffs (#188), because I wanted an easy-to-process DEM. I thought I'd share my implementation. 

My approach works roughly like this:

1. The geotiff workflow starts with the aggregation tiles. In addition to the pmtile I also create a geotiff from the aggregation tile and save it in the `geotiff-store` path. See `aggregation_geotiff.py`
2. I then create a tile pyramid of geotiffs. I introspect which files are in `geotiff-store` to figure out which geotiffs still need to be created. For creating a geotiff at level `z`, I use a mosaic of tiles from level `z+1`. The resolution of the geotiff is defined by the last number in the file name, i.e. analog to the `child_z` you already use. I use the best resolution available, but also limit it to at most  64*512=32768 pixels. See `downsampling_geotiff.py`
3. As a last step I create a VRT for each zoom level from `6` (which already covers the world with one tile) to `17` (which has only data where it is actually available - for now that's the swissAlt3D extent).

Afterwards i can use gdal to easily work with the geotiffs. E.g.:

```sh
# Get DEM for Austria at different zoom levles
gdalwarp -cutline at.gpkg -crop_to_cutline geotiff-store/z8.vrt at-z8.tif
gdalwarp -cutline at.gpkg -crop_to_cutline geotiff-store/z16.vrt at-z16.tif

# This one is not particularly useful, since it has no data everywhere except a small border region towards Switzerland, but a nice test case
gdalwarp -cutline at.gpkg -crop_to_cutline geotiff-store/z17.vrt at-z17.tif
```