### PR TITLE
Store source zoom directly in bounds.csv

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -24,7 +24,7 @@ The source pipeline has multiple parts that are needed to bring source files int
 
 `source_normalize_filenames.py`: Use this if you have strange filenames.
 
-`source_bounds.py`: Required script. Creates `source-store/{source}/bounds.csv` needed for the aggregation covering stage.
+`source_bounds.py`: Required script. Creates `source-store/{source}/bounds.csv` needed for the aggregation covering stage. The stored width and height are effective pixel counts, chosen such that bounding box size divided by count gives the true pixel size in EPSG:3857.
 
 `source_polygonize.py`: Required script. Creates `polygon-store/{source}.gpkg` with the coverage polygon of the source. Needed for the tarball creation and the coverage pmtiles part.
 

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -24,7 +24,7 @@ The source pipeline has multiple parts that are needed to bring source files int
 
 `source_normalize_filenames.py`: Use this if you have strange filenames.
 
-`source_bounds.py`: Required script. Creates `source-store/{source}/bounds.csv` needed for the aggregation covering stage. The stored width and height are effective pixel counts, chosen such that bounding box size divided by count gives the true pixel size in EPSG:3857.
+`source_bounds.py`: Required script. Creates `source-store/{source}/bounds.csv` needed for the aggregation covering stage. Each row stores the source `zoom`, the smallest web mercator zoom whose pixel size is finer than the source resolution in both raster-axis directions. The resolution is measured in EPSG:3857 at the raster center so the inflated transformed bounding box of a rotated image does not make the pipeline select a zoom one level too low.
 
 `source_polygonize.py`: Required script. Creates `polygon-store/{source}.gpkg` with the coverage polygon of the source. Needed for the tarball creation and the coverage pmtiles part.
 
@@ -51,7 +51,7 @@ In **covering**, we loop over all source bounds.csv files and all source files (
 
 These zoom 12 tiles are called "macrotiles". We then store in a map which macrotiles intersect which source items.
 
-For every source item we furthermore compute the smallest web mercator zoom level to oversample the source data. Here is where we use the pixel size and bounding box from the bounds.csv file.
+For every source item we read its source zoom from the bounds.csv file and apply the aggregation pipeline's minimum zoom of 12. The source zoom is the smallest web mercator zoom whose pixel size is finer than the source resolution in both raster-axis directions.
 
 Throughout Mapterhorn we assume a final tile size of 512 by 512 pixels. Intermediate working tiles can also be larger but never smaller.
 

--- a/pipelines/aggregation_covering.py
+++ b/pipelines/aggregation_covering.py
@@ -5,14 +5,6 @@ from ulid import ULID
 
 import utils
 
-def get_mercator_resolutions(minzoom, maxzoom):
-    resolutions = []
-    for z in range(minzoom, maxzoom + 1):
-        tile = mercantile.Tile(x=0, y=0, z=z)
-        bounds = mercantile.xy_bounds(tile)
-        resolutions.append((bounds.right - bounds.left) / 512)
-    return resolutions
-
 def bounds_intersect_no_anitmeridian_crossing(a, b):
     left_a, bottom_a, right_a, top_a = a
     left_b, bottom_b, right_b, top_b = b
@@ -52,17 +44,18 @@ def get_intersecting_tiles_dfs(bounds, tile, zoom):
 def get_macrotile_map():
     macrotile_map = {}
     filepaths = sorted(glob('source-store/*/bounds.csv'))
-    mercator_resolutions = get_mercator_resolutions(0, 32)
     for filepath in filepaths:
         print(f'reading {filepath}...')
         source = filepath.split('/')[1]
         with open(filepath) as f:
-            f.readline() # skip header
+            header = f.readline().strip()
+            if header != 'filename,left,bottom,right,top,zoom':
+                raise ValueError(f'Unexpected bounds.csv header. filepath={filepath} header={header}')
             line = f.readline().strip()
             while line != '':
-                filename, left, bottom, right, top, width, height = line.split(',')
-                width, height = [int(a) for a in [width, height]]
+                filename, left, bottom, right, top, source_zoom = line.split(',')
                 left, bottom, right, top = [float(a) for a in [left, bottom, right, top]]
+                source_zoom = int(source_zoom)
 
                 multiplier = 2
                 buffer = multiplier * utils.macrotile_buffer_3857
@@ -74,8 +67,6 @@ def get_macrotile_map():
                 )
 
                 tiles = get_intersecting_tiles_dfs(buffered_bounds, mercantile.Tile(x=0, y=0, z=0), utils.macrotile_z)
-                
-                maxzoom = get_smallest_overzoom(left, bottom, right, top, width, height, mercator_resolutions)
 
                 # Use at least a maxzoom of 12 (macrotile_z).
                 # Note that glo30 does not everywhere give a maxzoom of 12. Examples:
@@ -84,7 +75,7 @@ def get_macrotile_map():
                 # N50 native maxzoom 11
                 # N49 native maxzoom 12 (group has only ~30 percent of total macrotiles)
                 # Use gdal warp with cubicspline when maxzoom is 12
-                maxzoom = max(maxzoom, utils.macrotile_z)
+                maxzoom = max(source_zoom, utils.macrotile_z)
 
                 for tile in tiles:
                     if (tile.x, tile.y) not in macrotile_map:
@@ -98,15 +89,6 @@ def get_macrotile_map():
                 line = f.readline().strip()
 
     return macrotile_map
-
-def get_smallest_overzoom(left, bottom, right, top, width, height, mercator_resolutions):
-    horizontal_resolution = (right - left) / width if left < right else (left - right) / width
-    vertical_resolution = (top - bottom) / height
-
-    for z in range(len(mercator_resolutions)):
-        if mercator_resolutions[z] < horizontal_resolution and mercator_resolutions[z] < vertical_resolution:
-            return z
-    raise ValueError(f'No overzoom found. (left, bottom, right, top, width, height) = {(left, bottom, right, top, width, height)}')
 
 def add_group_ids(macrotile_map):
     for tile_tuple in macrotile_map:

--- a/pipelines/source_bounds.py
+++ b/pipelines/source_bounds.py
@@ -2,10 +2,27 @@ from glob import glob
 import sys
 import math
 
+import mercantile
 import rasterio
 from rasterio.warp import transform, transform_bounds
 
 import utils
+
+def get_mercator_resolutions(minzoom, maxzoom):
+    resolutions = []
+    for z in range(minzoom, maxzoom + 1):
+        tile = mercantile.Tile(x=0, y=0, z=z)
+        bounds = mercantile.xy_bounds(tile)
+        resolutions.append((bounds.right - bounds.left) / 512)
+    return resolutions
+
+def get_source_zoom(resolution_x, resolution_y, mercator_resolutions):
+    # Smallest web mercator zoom whose pixel size is finer than the source
+    # resolution in both raster-axis directions.
+    for z in range(len(mercator_resolutions)):
+        if mercator_resolutions[z] < resolution_x and mercator_resolutions[z] < resolution_y:
+            return z
+    raise ValueError(f'No source zoom found. resolutions = {(resolution_x, resolution_y)}')
 
 def get_resolutions_3857(src):
     # Returns the true resolution of an image in EPSG:3857 units, measured at
@@ -39,7 +56,9 @@ def main():
     
     filepaths = sorted(glob(f'source-store/{source}/*.tif'))
 
-    bounds_file_lines = ['filename,left,bottom,right,top,width,height\n']
+    mercator_resolutions = get_mercator_resolutions(0, 32)
+
+    bounds_file_lines = ['filename,left,bottom,right,top,zoom\n']
 
     for j, filepath in enumerate(filepaths):
         with rasterio.open(filepath) as src:
@@ -57,21 +76,19 @@ def main():
                 if not math.isfinite(num):
                     raise ValueError(f'Number in bounds is not finite. src.bounds={src.bounds} src.crs={src.crs} bounds={(left, bottom, right, top)}')
 
-            # width and height are effective pixel counts, chosen such that
-            # bounding box size / count gives the true resolution. With the raw
-            # raster counts, get_smallest_overzoom in aggregation_covering.py
-            # would overestimate the resolution of rotated images and could
-            # pick a maxzoom which does not fully resolve them.
+            # Store the source zoom directly rather than a pixel count. Measure
+            # the resolution in EPSG:3857 at the raster center because the
+            # transformed bounding box of a rotated image can be inflated and
+            # select a zoom one level too low. The aggregation applies its own
+            # macrotile_z floor.
             resolution_x, resolution_y = get_resolutions_3857(src)
             for num in [resolution_x, resolution_y]:
                 if not math.isfinite(num) or num <= 0:
                     raise ValueError(f'Resolution is not finite and positive. src.crs={src.crs} resolutions={(resolution_x, resolution_y)}')
-            width_3857 = right - left if left < right else left - right
-            width = max(1, round(width_3857 / resolution_x))
-            height = max(1, round((top - bottom) / resolution_y))
+            zoom = get_source_zoom(resolution_x, resolution_y, mercator_resolutions)
 
             filename = filepath.split('/')[-1]
-            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{width},{height}\n')
+            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{zoom}\n')
             if j % 100 == 0:
                 print(f'{j} / {len(filepaths)}')
 

--- a/pipelines/source_bounds.py
+++ b/pipelines/source_bounds.py
@@ -3,9 +3,30 @@ import sys
 import math
 
 import rasterio
-from rasterio.warp import transform_bounds
+from rasterio.warp import transform, transform_bounds
 
 import utils
+
+def get_resolutions_3857(src):
+    # Returns the true resolution of an image in EPSG:3857 units, measured at
+    # the raster center by reprojecting one pixel step in each axis direction.
+    # For an image whose CRS is rotated against web mercator, like polar
+    # stereographic, this is smaller than bounding box size / pixel count,
+    # because the bounding box of a rotated image is inflated by up to sqrt(2).
+    center_col = src.width / 2
+    center_row = src.height / 2
+    x0, y0 = src.transform * (center_col, center_row)
+    x1, y1 = src.transform * (center_col + 1, center_row)
+    x2, y2 = src.transform * (center_col, center_row + 1)
+    xs, ys = transform(src.crs, 'EPSG:3857', [x0, x1, x2], [y0, y1, y2])
+    dxs = []
+    for x in [xs[1], xs[2]]:
+        dx = abs(x - xs[0])
+        # a pixel step across the antimeridian wraps around in x
+        dxs.append(min(dx, 2 * utils.X_MAX_3857 - dx))
+    resolution_x = math.hypot(dxs[0], ys[1] - ys[0])
+    resolution_y = math.hypot(dxs[1], ys[2] - ys[0])
+    return resolution_x, resolution_y
 
 def main():
     source = None
@@ -35,8 +56,22 @@ def main():
             for num in [left, bottom, right, top]:
                 if not math.isfinite(num):
                     raise ValueError(f'Number in bounds is not finite. src.bounds={src.bounds} src.crs={src.crs} bounds={(left, bottom, right, top)}')
+
+            # width and height are effective pixel counts, chosen such that
+            # bounding box size / count gives the true resolution. With the raw
+            # raster counts, get_smallest_overzoom in aggregation_covering.py
+            # would overestimate the resolution of rotated images and could
+            # pick a maxzoom which does not fully resolve them.
+            resolution_x, resolution_y = get_resolutions_3857(src)
+            for num in [resolution_x, resolution_y]:
+                if not math.isfinite(num) or num <= 0:
+                    raise ValueError(f'Resolution is not finite and positive. src.crs={src.crs} resolutions={(resolution_x, resolution_y)}')
+            width_3857 = right - left if left < right else left - right
+            width = max(1, round(width_3857 / resolution_x))
+            height = max(1, round((top - bottom) / resolution_y))
+
             filename = filepath.split('/')[-1]
-            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{src.width},{src.height}\n')
+            bounds_file_lines.append(f'{filename},{left},{bottom},{right},{top},{width},{height}\n')
             if j % 100 == 0:
                 print(f'{j} / {len(filepaths)}')
 


### PR DESCRIPTION
Implements the fix discussed in https://github.com/mapterhorn/mapterhorn/pull/273#issuecomment-4874015336: `get_smallest_overzoom()` infers resolution from the axis-aligned EPSG:3857 bounding box, so tiles rotated against the Web Mercator axes (polar stereographic REMA/ArcticDEM, up to 45 deg) overestimate resolution by up to √2 and can pick a **maxzoom one level too low** (~27% of REMA tiles).

`source_bounds.py` now measures the true resolution at the raster center (one-pixel steps through the full affine transform, reprojected to EPSG:3857) and writes **effective pixel counts** to bounds.csv, such that bounding box / count = true resolution. `get_smallest_overzoom()` and every other consumer are unchanged, and bounds.csv files inside already-published tarballs keep working.

Notes:
- Unrotated sources stay within rounding of the raster dimensions (UTM moves ~1 px from grid convergence - no zoom changes).
- Tiles straddling the antimeridian (REMA's Ross Sea sector) previously got a huge resolution from the wrapped bounding box and were capped at maxzoom 12; they now resolve to their true maxzoom.
- Alternative considered: keep raw width/height and add res_x/res_y columns. More self-describing, but the schema change means the covering parser needs a fallback for the 7-column bounds.csv inside every published tarball, forever.

Verified with synthetic 512x512 EPSG:3031 tiles (45 deg rotation -> counts 724x724, maxzoom 13 -> 14; unrotated and EPSG:32632 tiles unchanged; antimeridian tile matches its unrotated neighbor) and on a real REMA 2 m subset (implied resolution 6.79 vs 7.23 from the old estimate, matching its 3.8 deg effective rotation).