### PR TITLE
Add Manager/Worker

### DIFF
--- a/pipelines/aggregation_covering.py
+++ b/pipelines/aggregation_covering.py
@@ -177,6 +177,21 @@ def write_aggregation_items(macrotile_map, aggregation_tiles, aggregation_id):
         with open(f'{folder}/{aggregation_tile.z}-{aggregation_tile.x}-{aggregation_tile.y}-{child_z}-aggregation.csv', 'w') as f:
             f.writelines(lines)
 
+def write_aggregation_todos():
+    aggregation_ids = utils.get_aggregation_ids()
+    aggregation_id = aggregation_ids[-1]
+
+    dirty_filepaths = None
+    if len(aggregation_ids) < 2:
+        dirty_filepaths = sorted(glob(f'aggregation-store/{aggregation_id}/*-aggregation.csv'))
+    else:
+        last_aggregation_id = aggregation_ids[-2]
+        dirty_filepaths = [f'aggregation-store/{aggregation_id}/{filename}' for filename in utils.get_dirty_aggregation_filenames(aggregation_id, last_aggregation_id)]
+    
+    for dirty_filepath in dirty_filepaths:
+        with open(f'{dirty_filepath}.todo', 'w') as f:
+            f.write('')
+
 def main():
 
     print('get_macrotile_map...')
@@ -193,6 +208,10 @@ def main():
 
     print('write aggregation items...')
     write_aggregation_items(macrotile_map, aggregation_tiles, aggregation_id)
+
+    print('write aggregation todos...')
+    write_aggregation_todos()
+
 
 if __name__ == '__main__':
     main()

--- a/pipelines/aggregation_merge.py
+++ b/pipelines/aggregation_merge.py
@@ -10,12 +10,10 @@ from scipy import ndimage
 import utils
 
 
-def merge(filepath):
-    _, aggregation_id, filename = filepath.split('/')
+def merge(filepath, tmp_folder):
+    filename = filepath.split('/')[-1]
 
-    z, x, y, child_z = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
-
-    tmp_folder = f'aggregation-store/{aggregation_id}/{z}-{x}-{y}-{child_z}-tmp'
+    _, x, y, __ = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
 
     done_filepath = f'{tmp_folder}/merge-done'
     if os.path.isfile(done_filepath):

--- a/pipelines/aggregation_reproject.py
+++ b/pipelines/aggregation_reproject.py
@@ -8,6 +8,7 @@ import numpy as np
 import utils
 
 SILENT = True
+FAIL_ON_WARNING = False
 
 def create_virtual_raster(tmp_folder, i, source_items):
     source = source_items[0]['source']
@@ -42,7 +43,7 @@ def create_warp(vrt_filepath, vrt_3857_filepath, zoom, aggregation_tile, buffer)
     command += '-dstnodata -9999 '
     command += f'{vrt_filepath} {vrt_3857_filepath}'
     out, err = utils.run_command(command, silent=SILENT)
-    if err.strip() != '':
+    if err.strip() != '' and FAIL_ON_WARNING:
         raise Exception(f'gdalwarp failed for {vrt_filepath}:\n{out}\n{err}')
 
 def translate(in_filepath, out_filepath):
@@ -52,7 +53,7 @@ def translate(in_filepath, out_filepath):
     command += f'{in_filepath} '
     command += f'{out_filepath}'
     out, err = utils.run_command(command, silent=SILENT)
-    if err.strip() != '':
+    if err.strip() != '' and FAIL_ON_WARNING:
         raise Exception(f'gdal_translate failed for {in_filepath}:\n{out}\n{err}')
 
 def contains_nodata_pixels(filepath):
@@ -72,15 +73,12 @@ def contains_nodata_pixels(filepath):
                         return True
     return False
 
-def reproject(filepath):
-    _, aggregation_id, filename = filepath.split('/')
+def reproject(filepath, tmp_folder):
+    filename = filepath.split('/')[-1]
 
-    z, x, y, child_z = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
+    z, x, y, _ = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
     
     aggregation_tile = mercantile.Tile(x=x, y=y, z=z)
-
-    tmp_folder = f'aggregation-store/{aggregation_id}/{aggregation_tile.z}-{aggregation_tile.x}-{aggregation_tile.y}-{child_z}-tmp'
-    utils.create_folder(tmp_folder)
 
     metadata_filepath = f'{tmp_folder}/reprojection.json'
     if os.path.isfile(metadata_filepath):

--- a/pipelines/aggregation_run.py
+++ b/pipelines/aggregation_run.py
@@ -11,27 +11,26 @@ import utils
 def run(filepath):
     filename = filepath.split('/')[-1]
     item = filename.replace('-aggregation.csv', '')
+    if os.path.isfile(f'{filepath}.done'):
+        print(f'Aggregation item {item} already done. Skipping...')
+        return
     print(f'{item} start')
-    aggregation_reproject.reproject(filepath)
-    aggregation_merge.merge(filepath)
-    aggregation_tile.main(filepath)
-    tmp_folder = filepath.replace('-aggregation.csv', '-tmp')
-    shutil.rmtree(tmp_folder)
-    utils.run_command(f'touch {filepath.replace("-aggregation.csv", "-aggregation.done")}')
+    tmp_folder = f'tmp-store/{item}'
+    os.makedirs(tmp_folder, exist_ok=True)
+    aggregation_reproject.reproject(filepath, tmp_folder)
+    aggregation_merge.merge(filepath, tmp_folder)
+    aggregation_tile.main(filepath, tmp_folder)
+    # shutil.rmtree(tmp_folder)
+    os.rename(f'{filepath}.todo', f'{filepath}.done')
     print(f'{item} end')
 
 def main():
+    
     aggregation_ids = utils.get_aggregation_ids()
     aggregation_id = aggregation_ids[-1]
 
-    dirty_filepaths = None
-    if len(aggregation_ids) < 2:
-        dirty_filepaths = sorted(glob(f'aggregation-store/{aggregation_id}/*-aggregation.csv'))
-    else:
-        last_aggregation_id = aggregation_ids[-2]
-        dirty_filepaths = [f'aggregation-store/{aggregation_id}/{filename}' for filename in utils.get_dirty_aggregation_filenames(aggregation_id, last_aggregation_id)]
+    dirty_filepaths = [filepath.replace('.todo', '') for filepath in glob(f'aggregation-store/{aggregation_id}/*-aggregation.csv.todo')]
     
-    dirty_filepaths = [filepath for filepath in dirty_filepaths if not os.path.isfile(filepath.replace('-aggregation.csv', '-aggregation.done'))]
     if len(dirty_filepaths) == 0:
         print('nothing to do.')
     else:

--- a/pipelines/aggregation_tile.py
+++ b/pipelines/aggregation_tile.py
@@ -45,12 +45,10 @@ def create_tile(i, j, tiff_filepath, out_filepath, buffer_pixels):
     subdata[subdata == -9999] = 0
     utils.save_terrarium_tile(subdata, out_filepath)
 
-def main(filepath):
-    _, aggregation_id, filename = filepath.split('/')
+def main(filepath, tmp_folder):
+    filename = filepath.split('/')[-1]
 
     z, x, y, child_z = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
-
-    tmp_folder = f'aggregation-store/{aggregation_id}/{z}-{x}-{y}-{child_z}-tmp'
 
 
     pmtiles_done_filepath = f'{tmp_folder}/pmtiles-done'

--- a/pipelines/downsampling_covering.py
+++ b/pipelines/downsampling_covering.py
@@ -33,7 +33,44 @@ def get_simplified_extents(extents, zoom):
             simplified_extents += list(mercantile.children(unlimited, zoom=zoom - utils.num_overviews))
     return simplified_extents
 
-def main():
+def tiles_intersect(a, b):
+    if a == b:
+        return True
+    if a.z < b.z and mercantile.parent(b, zoom=a.z) == a:
+        return True
+    if b.z < a.z and mercantile.parent(a, zoom=b.z) == b:
+        return True
+    return False
+
+def is_parent_of_dirty_aggregation_tile(tile, dirty_aggregation_tiles):
+    for dirty_aggregation_tile in dirty_aggregation_tiles:
+        if tiles_intersect(dirty_aggregation_tile, tile):
+            return True
+    return False
+
+def not_in_previous_aggregation(filename, aggregation_ids):
+    return len(glob(f'aggregation-store/{aggregation_ids[-2]}/{filename}')) == 0
+
+def write_downlsampling_todos():
+    aggregation_ids = utils.get_aggregation_ids()
+    aggregation_id = aggregation_ids[-1]
+
+    dirty_aggregation_tiles = []
+    if len(aggregation_ids) >= 2:
+        dirty_aggregation_filenames = utils.get_dirty_aggregation_filenames(aggregation_id, aggregation_ids[-2])
+        for filename in dirty_aggregation_filenames:
+            z, x, y, _ = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
+            dirty_aggregation_tiles.append(mercantile.Tile(x=x, y=y, z=z))
+
+    for filepath in sorted(glob(f'aggregation-store/{aggregation_id}/*-downsampling.csv')):
+        filename = filepath.split('/')[-1]
+        z, x, y, _ = [int(a) for a in filename.replace('-downsampling.csv', '').split('-')]
+
+        if len(aggregation_ids) < 2 or is_parent_of_dirty_aggregation_tile(mercantile.Tile(x=x, y=y, z=z), dirty_aggregation_tiles) or not_in_previous_aggregation(filename, aggregation_ids):
+            with open(f'{filepath}.todo', 'w') as f:
+                f.write('')
+    
+def write_downsampling_items():
     aggregation_ids = utils.get_aggregation_ids()
     aggregation_id = aggregation_ids[-1]
 
@@ -72,4 +109,5 @@ def main():
                 f.writelines(lines)
 
 if __name__ == '__main__':
-    main()
+    write_downsampling_items()
+    write_downlsampling_todos()

--- a/pipelines/downsampling_run.py
+++ b/pipelines/downsampling_run.py
@@ -13,7 +13,7 @@ from pmtiles.reader import Reader, MmapSource
 
 import utils
 
-def create_tile(parent_x, parent_y, parent_z, aggregation_id, tmp_folder, pmtiles_filenames):
+def create_tile(parent_x, parent_y, parent_z, tmp_folder, pmtiles_filenames):
     tile_to_pmtiles_filename = get_tile_to_pmtiles_filename(pmtiles_filenames)
     full_data = np.zeros((1024, 1024), dtype=np.float32)
     for row_offset in range(2):
@@ -65,87 +65,68 @@ def get_tile_to_pmtiles_filename(pmtiles_filenames):
             tile_to_pmtiles_filename[child] = pmtiles_filename
     return tile_to_pmtiles_filename
 
-def main(filepaths):
-    for j, filepath in enumerate(filepaths):
-        _, aggregation_id, filename = filepath.split('/')
-        print(f'downsampling {filename}. {datetime.now()}. {j + 1} / {len(filepaths)}.')
-        if os.path.isfile(filepath.replace("-downsampling.csv", "-downsampling.done")):
-            print('already done...')
-            continue
-        parts = filename.split('-')
-        extent_z, extent_x, extent_y, parent_zoom = [int(a) for a in parts[:4]]
+def downsample_single(filepath):
+    _, __, filename = filepath.split('/')
+    print(f'downsampling {filename}. {datetime.now()}')
+    if os.path.isfile(f'{filepath}.done'):
+        print('already done...')
+        return
+    parts = filename.split('-')
+    extent_z, extent_x, extent_y, parent_zoom = [int(a) for a in parts[:4]]
 
-        out_folder = utils.get_pmtiles_folder(extent_x, extent_y, extent_z)
-        utils.create_folder(out_folder)
-        out_filepath = f'{out_folder}/{extent_z}-{extent_x}-{extent_y}-{parent_zoom}.pmtiles'
+    out_folder = utils.get_pmtiles_folder(extent_x, extent_y, extent_z)
+    utils.create_folder(out_folder)
+    out_filepath = f'{out_folder}/{extent_z}-{extent_x}-{extent_y}-{parent_zoom}.pmtiles'
 
-        extent = mercantile.Tile(x=extent_x, y=extent_y, z=extent_z)
-        tmp_folder = filepath.replace('-downsampling.csv', '-tmp')
-        utils.create_folder(tmp_folder)
+    extent = mercantile.Tile(x=extent_x, y=extent_y, z=extent_z)
+    tmp_folder = f'tmp-store/{filename.replace("-downsampling.csv", "")}'
+    os.makedirs(tmp_folder, exist_ok=True)
 
-        pmtiles_filenames = None
-        with open(filepath) as f:
-            pmtiles_filenames = f.readlines()
-            pmtiles_filenames = pmtiles_filenames[1:] # skip header
-            pmtiles_filenames = [a.strip() for a in pmtiles_filenames]
+    pmtiles_filenames = None
+    with open(filepath) as f:
+        pmtiles_filenames = f.readlines()
+        pmtiles_filenames = pmtiles_filenames[1:] # skip header
+        pmtiles_filenames = [a.strip() for a in pmtiles_filenames]
 
-        parents = None
-        if extent_z == parent_zoom:
-            parents = [extent]
-        else:
-            parents = list(mercantile.children(extent, zoom=parent_zoom))
-        
-        argument_tuples = []
-        for parent in parents:
-            argument_tuples.append((parent.x, parent.y, parent.z, aggregation_id, tmp_folder, pmtiles_filenames))
+    parents = None
+    if extent_z == parent_zoom:
+        parents = [extent]
+    else:
+        parents = list(mercantile.children(extent, zoom=parent_zoom))
+    
+    for parent in parents:
+        create_tile(parent.x, parent.y, parent.z, tmp_folder, pmtiles_filenames)
+    
+    utils.create_archive(tmp_folder, out_filepath)
 
-        with Pool() as pool:
-            pool.starmap(create_tile, argument_tuples, chunksize=1)
-        
-        utils.create_archive(tmp_folder, out_filepath)
+    shutil.rmtree(tmp_folder)
+    os.rename(f'{filepath}.todo', f'{filepath}.done')
+    print(f'{filepath} done.')
 
-        shutil.rmtree(tmp_folder)
-        utils.run_command(f'touch {filepath.replace("-downsampling.csv", "-downsampling.done")}')
+def downsample_multiple(filepaths):
+    argument_tuples = [(filepath,) for filepath in filepaths]
+    with Pool() as pool:
+        pool.starmap(downsample_single, argument_tuples, chunksize=1)
 
-def tiles_intersect(a, b):
-    if a == b:
-        return True
-    if a.z < b.z and mercantile.parent(b, zoom=a.z) == a:
-        return True
-    if b.z < a.z and mercantile.parent(a, zoom=b.z) == b:
-        return True
-    return False
-
-def is_parent_of_dirty_aggregation_tile(tile, dirty_aggregation_tiles):
-    for dirty_aggregation_tile in dirty_aggregation_tiles:
-        if tiles_intersect(dirty_aggregation_tile, tile):
-            return True
-    return False
-
-def not_in_previous_aggregation(filename, aggregation_ids):
-    return len(glob(f'aggregation-store/{aggregation_ids[-2]}/{filename}')) == 0
-
-if __name__ == '__main__':
+def get_child_zoom_to_filepaths():
     child_zoom_to_filepaths = {}
     aggregation_ids = utils.get_aggregation_ids()
     aggregation_id = aggregation_ids[-1]
+    for todo_filepath in sorted(glob(f'aggregation-store/{aggregation_id}/*-downsampling.csv.todo')):
+        filename = todo_filepath.split('/')[-1]
+        _, __, ___, child_zoom = [int(a) for a in filename.replace('-downsampling.csv.todo', '').split('-')]
+        if child_zoom not in child_zoom_to_filepaths:
+            child_zoom_to_filepaths[child_zoom] = []
+        child_zoom_to_filepaths[child_zoom].append(todo_filepath.replace('.todo', ''))
+    return child_zoom_to_filepaths
 
-    dirty_aggregation_tiles = []
-    if len(aggregation_ids) >= 2:
-        dirty_aggregation_filenames = utils.get_dirty_aggregation_filenames(aggregation_id, aggregation_ids[-2])
-        for filename in dirty_aggregation_filenames:
-            z, x, y, _ = [int(a) for a in filename.replace('-aggregation.csv', '').split('-')]
-            dirty_aggregation_tiles.append(mercantile.Tile(x=x, y=y, z=z))
-
-    for filepath in sorted(glob(f'aggregation-store/{aggregation_id}/*-downsampling.csv')):
-        filename = filepath.split('/')[-1]
-        z, x, y, child_zoom = [int(a) for a in filename.replace('-downsampling.csv', '').split('-')]
-
-        if len(aggregation_ids) < 2 or is_parent_of_dirty_aggregation_tile(mercantile.Tile(x=x, y=y, z=z), dirty_aggregation_tiles) or not_in_previous_aggregation(filename, aggregation_ids):
-            if child_zoom not in child_zoom_to_filepaths:
-                child_zoom_to_filepaths[child_zoom] = []
-            child_zoom_to_filepaths[child_zoom].append(filepath)
-
+def main():
+    child_zoom_to_filepaths = get_child_zoom_to_filepaths()
     child_zooms = list(reversed(sorted(list(child_zoom_to_filepaths.keys()))))
     for child_zoom in child_zooms:
-        main(child_zoom_to_filepaths[child_zoom])
+        print(child_zoom)
+        print(len(child_zoom_to_filepaths[child_zoom]))
+        downsample_multiple(child_zoom_to_filepaths[child_zoom])
+
+if __name__ == '__main__':
+    main()

--- a/pipelines/eta.py
+++ b/pipelines/eta.py
@@ -28,13 +28,13 @@ def compute(kind):
     print()
     print(kind)
 
-    children_done = count_children(f'-{kind}.done')
+    children_done = count_children(f'-{kind}.csv.done')
     children_total = count_children(f'-{kind}.csv')
 
     print('time now:', datetime.now())
     print('done, all, percentage:', children_done, children_total, f'{(children_done / children_total):.1%}')
 
-    filepaths = glob(f'aggregation-store/{utils.get_aggregation_ids()[-1]}/*-{kind}.done')
+    filepaths = glob(f'aggregation-store/{utils.get_aggregation_ids()[-1]}/*-{kind}.csv.done')
     if len(filepaths) == 0:
         print('nothing done yet')
         exit()
@@ -47,4 +47,4 @@ def compute(kind):
 
 if __name__ == '__main__':
     compute('aggregation')
-    compute('downsampling')
+    # compute('downsampling')

--- a/pipelines/manager.py
+++ b/pipelines/manager.py
@@ -1,0 +1,88 @@
+from glob import glob
+import os
+
+import time
+
+import utils
+import downsampling_run
+
+def distribute_tasks(item_filepaths):
+    print('start distributing tasks...')
+    item_index = 0
+
+    while item_index < len(item_filepaths):
+        print(f'{item_index} tasks of {len(item_filepaths)} distributed')
+        task_requests = glob('task-store/*.request')
+        print(f'received {len(task_requests)} requests')
+        for task_request in task_requests:
+            task_response = task_request.replace('.request', '.response')
+            with open(f'{task_response}.tmp', 'w') as f:
+                f.write(item_filepaths[item_index])
+            os.replace(f'{task_response}.tmp', task_response)
+            os.remove(task_request)
+            item_index += 1
+            if item_index == len(item_filepaths):
+                break
+        time.sleep(1)
+    
+    print('all task are distributed')
+
+def manage_aggregation():
+    print('manage aggregation...')
+
+    aggregation_ids = utils.get_aggregation_ids()
+    aggregation_id = aggregation_ids[-1]
+
+    item_filepaths = [filepath.replace('.todo', '') for filepath in glob(f'aggregation-store/{aggregation_id}/*-aggregation.csv.todo')]
+    
+    if len(item_filepaths) == 0:
+        print('nothing to do.')
+        return
+    else:
+        print(f'start distributing {len(item_filepaths)} aggregation items...')
+
+
+    distribute_tasks(item_filepaths)
+
+    while True:
+        all_done = True
+        for item_filepath in reversed(item_filepaths):
+            if not os.path.isfile(f'{item_filepath}.done'):
+                print('not done yet...')
+                all_done = False
+                break
+        if all_done:
+            break
+        time.sleep(3)
+                                     
+    
+    print('aggregation done.')
+
+
+def manage_downsampling():
+
+    print('manage aggregation...')
+
+    child_zoom_to_filepaths = downsampling_run.get_child_zoom_to_filepaths()
+    child_zooms = list(reversed(sorted(list(child_zoom_to_filepaths.keys()))))
+    for child_zoom in child_zooms:
+        print(child_zoom)
+        print(len(child_zoom_to_filepaths[child_zoom]))
+        distribute_tasks(child_zoom_to_filepaths[child_zoom])
+
+        while True:
+            all_done = True
+            for item_filepath in reversed(child_zoom_to_filepaths[child_zoom]):
+                if not os.path.isfile(f'{item_filepath}.done'):
+                    print('not done yet...')
+                    all_done = False
+                    break
+            if all_done:
+                break
+            time.sleep(3)
+                                        
+        print('downsampling done.')
+    
+if __name__ == '__main__':
+    # manage_aggregation()
+    manage_downsampling()

--- a/pipelines/worker.py
+++ b/pipelines/worker.py
@@ -1,0 +1,74 @@
+import time
+from multiprocessing import Process
+import secrets
+import os
+
+import aggregation_run
+import downsampling_run
+
+def worker():
+    print('starting worker...')
+    while True:
+        task_name = secrets.token_hex(16)
+        filename = f'task-store/{task_name}.request'
+        with open(filename, 'w') as f:
+            f.write('')
+        
+        sleep_iterations = 0
+        while not os.path.isfile(f'task-store/{task_name}.response'):
+            time.sleep(1)
+            sleep_iterations += 1
+            if sleep_iterations == 600:
+                os.remove(f'task-store/{task_name}.request')
+                print('task response timed out. terminating...')
+                return
+        
+        filepath = None
+        with open(f'task-store/{task_name}.response') as f:
+            lines = f.readlines()
+            assert len(lines) == 1
+            filepath = lines[0].strip()
+        
+        os.remove(f'task-store/{task_name}.response')
+
+        if filepath.endswith('-aggregation.csv'):
+            aggregation_run.run(filepath)
+        elif filepath.endswith('-downsampling.csv'):
+            downsampling_run.downsample_single(filepath)
+        else:
+            print(f'unknown task {filepath}')
+            raise Exception()
+  
+def run_pool():
+    print('starting pool...')
+    processes = [Process(target=worker) for _ in range(32)]
+    for p in processes:
+        p.start()
+    
+    while True:
+        dead_processes = []
+        for p in processes:
+            if not p.is_alive():
+                p.join()
+                dead_processes.append(p)
+        
+        for p in dead_processes:
+            if p.exitcode != 0:
+                for other in processes:
+                    if other.is_alive():
+                        other.terminate()
+
+                for other in processes:
+                    other.join()
+
+                raise Exception()
+        
+        if len(dead_processes) == len(processes):
+            break
+
+        time.sleep(1)
+
+    print('all processes are terminated.')
+
+if __name__ == '__main__':
+    run_pool()


### PR DESCRIPTION
Reworks the parallelization towards multi-host computing. Let's assume that we have the following folders on network shares: source-store, aggregation-store, pmtiles-store, and a new task-store.
Now the aggreagtion_covering.py and downsample_covering.py scripts just write items to the aggreagtion-store folder.
All machines mount these folders over the network. They announce themselves as "open to work" by writing to a `task-store/<random-number>.request` file. This request is made by worker.py. Then manager.py, run on a single machine, looks a at the requests in the task-store folder, and writes `task-store/<random-number>.response` containing the filepath of the aggregation or downsampling item. The worker sees the response and starts with the work.
Previously we kept temporary files in the aggreation-store. Now those are on a local "tmp-store" folder.
Tested with two machines each with 32 threads. Seems to work nicely because the aggregation and downsampling is so heavily CPU bound.