### PR TITLE
Fix source_create_tarball.py

### DIFF
--- a/pipelines/source_create_tarball.py
+++ b/pipelines/source_create_tarball.py
@@ -17,27 +17,27 @@ def main():
 
     utils.create_folder('tar-store/')
     checksum = None
-    filepath = f'tar-store/{source}.tar'
-    with open(filepath, 'wb') as f:
+    out_filepath = f'tar-store/{source}.tar'
+    with open(out_filepath, 'wb') as f:
         writer = utils.HashWriter(f)
         with tarfile.open(fileobj=writer, mode='w') as tar:
             tar.add(f'../source-catalog/{source}/LICENSE.pdf', 'LICENSE.pdf')
             tar.add(f'../source-catalog/{source}/metadata.json', 'metadata.json')
             tar.add(f'source-store/{source}/bounds.csv', 'bounds.csv')
             tar.add(f'polygon-store/{source}.gpkg', 'coverage.gpkg')
-            filepaths = glob(f'source-store/{source}/*.tif')
-            for j, filepath in enumerate(filepaths, 1):
+            in_filepaths = glob(f'source-store/{source}/*.tif')
+            for j, in_filepath in enumerate(in_filepaths, 1):
                 if j % 1000 == 0:
-                    print(f'{j:_} / {len(filepaths):_}')
-                filename = filepath.split('/')[-1]
-                tar.add(filepath, f'files/{filename}')
+                    print(f'{j:_} / {len(in_filepaths):_}')
+                in_filename = in_filepath.split('/')[-1]
+                tar.add(in_filepath, f'files/{in_filename}')
         checksum = writer.md5.hexdigest()
 
-    filesize = os.path.getsize(filepath)
+    out_filesize = os.path.getsize(out_filepath)
     utils.create_folder('meta-store/tar/')
     with open(f'meta-store/tar/{source}.json', 'w') as f:
         json.dump({
-            'size': filesize,
+            'size': out_filesize,
             'md5sum': checksum,
         }, f, indent=2)
 


### PR DESCRIPTION
Before we had the file size of the last tif inside the meta-store json file instead of the full tarball size...